### PR TITLE
windows use UV_TTY_MODE_RAW_VT

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -522,6 +522,11 @@ bare_tty_exports(js_env_t *env, js_value_t *exports) {
 
   V("MODE_NORMAL", UV_TTY_MODE_NORMAL)
   V("MODE_RAW", UV_TTY_MODE_RAW)
+#if UV_VERSION_HEX >= 0x013000 // libuv >= 1.48.0 introduced UV_TTY_MODE_RAW_VT
+  V("MODE_RAW_VT", UV_TTY_MODE_RAW_VT)
+#else
+  V("MODE_RAW_VT", UV_TTY_MODE_RAW) // fallback: behaves like RAW on old libuv
+#endif
 #ifndef _WIN32
   V("MODE_IO", UV_TTY_MODE_IO)
 #endif

--- a/index.js
+++ b/index.js
@@ -36,7 +36,12 @@ exports.ReadStream = class TTYReadStream extends Readable {
   }
 
   setRawMode(enabled) {
-    return this.setMode(enabled ? constants.mode.RAW : constants.mode.NORMAL)
+    if (!enabled) return this.setMode(constants.mode.NORMAL)
+    // On Windows, RAW leaves libuv translating console records itself and never
+    // emits \x1b[Z for Shift+Tab; RAW_VT sets ENABLE_VIRTUAL_TERMINAL_INPUT so
+    // the console emits real VT sequences. Other platforms already work on RAW.
+    const raw = Bare.platform === 'win32' ? constants.mode.RAW_VT : constants.mode.RAW
+    return this.setMode(raw)
   }
 
   _read() {

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,5 +1,5 @@
 declare const constants: {
-  mode: { NORMAL: number; RAW: number; IO: number }
+  mode: { NORMAL: number; RAW: number; RAW_VT: number; IO: number }
   state: { READING: number; CLOSING: number }
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,6 +4,7 @@ module.exports = exports = {
   mode: {
     NORMAL: binding.MODE_NORMAL,
     RAW: binding.MODE_RAW,
+    RAW_VT: binding.MODE_RAW_VT || binding.MODE_RAW,
     IO: binding.MODE_IO || 0
   },
 
@@ -17,5 +18,7 @@ module.exports = exports = {
 exports.MODE_NORMAL = exports.mode.NORMAL
 /** @deprecated Use `mode.RAW` */
 exports.MODE_RAW = exports.mode.RAW
+/** @deprecated Use `mode.RAW_VT` */
+exports.MODE_RAW_VT = exports.mode.RAW_VT
 /** @deprecated Use `mode.IO` */
 exports.MODE_IO = exports.mode.IO


### PR DESCRIPTION
I needed shift+tab to work on windows. 

UV_TTY_MODE_RAW_VT is available on libuv >= 1.48.0. 

 On Windows, RAW leaves libuv translating console records itself and never emits \x1b[Z for Shift+Tab; RAW_VT sets ENABLE_VIRTUAL_TERMINAL_INPUT so the console emits real VT sequences. Other platforms already work on RAW.
 
 I have tested this and it works for bare-tui and bare-tui-form

This change was authored by Claude code. 